### PR TITLE
Add support for enabling autologin in the deluge webui.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ docker run -d \
     -e NAME_SERVERS=<name server ip(s)> \
     -e DELUGE_DAEMON_LOG_LEVEL=<info|warning|error|none|debug|trace|garbage> \
     -e DELUGE_WEB_LOG_LEVEL=<info|warning|error|none|debug|trace|garbage> \
+    -e DELUGE_AUTOLOGIN=<yes|no> \
     -e ADDITIONAL_PORTS=<port number(s)> \
     -e DEBUG=<true|false> \
     -e UMASK=<umask for created files> \
@@ -85,6 +86,7 @@ docker run -d \
     -e NAME_SERVERS=209.222.18.222,84.200.69.80,37.235.1.174,1.1.1.1,209.222.18.218,37.235.1.177,84.200.70.40,1.0.0.1 \
     -e DELUGE_DAEMON_LOG_LEVEL=info \
     -e DELUGE_WEB_LOG_LEVEL=info \
+    -e DELUGE_AUTOLOGIN=no \
     -e ADDITIONAL_PORTS=1234 \
     -e DEBUG=false \
     -e UMASK=000 \
@@ -124,6 +126,7 @@ docker run -d \
     -e NAME_SERVERS=209.222.18.222,84.200.69.80,37.235.1.174,1.1.1.1,209.222.18.218,37.235.1.177,84.200.70.40,1.0.0.1 \
     -e DELUGE_DAEMON_LOG_LEVEL=info \
     -e DELUGE_WEB_LOG_LEVEL=info \
+    -e DELUGE_AUTOLOGIN=no \
     -e DEBUG=false \
     -e ADDITIONAL_PORTS=1234 \
     -e UMASK=000 \

--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -152,3 +152,6 @@ rm /tmp/envvars_heredoc
 
 # cleanup
 cleanup.sh
+
+# install patch
+pacman -S --needed patch --noconfirm

--- a/run/nobody/deluge.sh
+++ b/run/nobody/deluge.sh
@@ -2,6 +2,9 @@
 
 if [[ "${deluge_running}" == "false" ]]; then
 
+	# run webui-autologin-patch
+	/home/nobody/webui-autologin-patch.sh
+
 	echo "[info] Attempting to start Deluge..."
 
 	echo "[info] Removing deluge pid file (if it exists)..."

--- a/run/nobody/webui-autologin-patch.sh
+++ b/run/nobody/webui-autologin-patch.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+PATCH=$(cat <<'EOF'
+diff -Naur deluge-orig/ui/web/auth.py deluge/ui/web/auth.py
+--- deluge-orig/ui/web/auth.py  2020-07-19 09:09:15.000000000 +0000
++++ deluge/ui/web/auth.py       2021-01-22 05:53:59.396212944 +0000
+@@ -122,6 +122,7 @@
+         return True
+
+     def check_password(self, password):
++        return True
+         config = self.config
+         if 'pwd_sha1' not in config.config:
+             log.debug('Failed to find config login details.')
+diff -Naur deluge-orig/ui/web/js/deluge-all-debug.js deluge/ui/web/js/deluge-all-debug.js
+--- deluge-orig/ui/web/js/deluge-all-debug.js   2020-07-19 09:09:15.000000000 +0000
++++ deluge/ui/web/js/deluge-all-debug.js        2021-01-22 05:50:44.149705748 +0000
+@@ -7430,7 +7430,7 @@
+     },
+
+     onShow: function() {
+-        this.passwordField.focus(true, 300);
++        this.onLogin();
+     },
+ });
+ /**
+EOF
+)
+PATH=$(echo -e "import sys, os\nfor path in sys.path:\n  if os.path.exists(path + 'deluge/') == True:\n    print(path)" | python)
+
+# apply patch to bypass web ui login
+export DELUGE_AUTOLOGIN=$(echo "${DELUGE_AUTOLOGIN}" | /usr/sbin/sed -e 's~^[ \t]*~~;s~[ \t]*$~~')
+if [[ ! -z "${DELUGE_AUTOLOGIN}" ]]; then
+    echo "[info] DELUGE_AUTOLOGIN defined as '${DELUGE_AUTOLOGIN}'" | /usr/sbin/ts '%Y-%m-%d %H:%M:%.S'
+    if [[ ! -z "${PATH}" ]]; then
+        if [ "${DELUGE_AUTOLOGIN}" != "no" ] && [ "${DELUGE_AUTOLOGIN}" != "No" ] && [ "${DELUGE_AUTOLOGIN}" != "NO" ]; then
+            echo "[info] Patching deluge to disable login prompt" | /usr/sbin/ts '%Y-%m-%d %H:%M:%.S'
+            echo "$PATCH" | /usr/sbin/patch -d$PATH/ -p0 > /dev/null
+        else
+            echo "[info] Removing patch to disable login prompt" | /usr/sbin/ts '%Y-%m-%d %H:%M:%.S'
+            echo "$PATCH" | /usr/sbin/patch -d$PATH/ -p0 -R > /dev/null
+        fi  
+    else
+        echo "[info] Unable to find deluge package, skipping DELUGE_AUTOLOGIN configuration." | /usr/sbin/ts '%Y-%m-%d %H:%M:%.S'
+    fi
+fi


### PR DESCRIPTION
This adds a new env var that can enable and disable the webui password prompt. Fixes #100  

DELUGE_AUTOLOGIN ="yes" or DELUGE_AUTOLOGIN ="no"

@binhex take a look at the changeset and let me know if you'd prefer that I change the way this is implemented. It makes more sense to me to exclude the 'patch' package from the aur.sh and cleanup.sh scripts in your other repository and install it as part of the pacman package install step earlier in install.sh instead of installing it after the cleanup.sh step in install.sh