### PR TITLE
Make the ifconfig output more portable

### DIFF
--- a/run/root/iptable.sh
+++ b/run/root/iptable.sh
@@ -10,13 +10,13 @@ default_gateway=$(ip route show default | awk '/default/ {print $3}')
 echo "[info] Default route for container is ${default_gateway}"
 
 # identify ip for docker bridge interface
-docker_ip=$(ifconfig "${docker_interface}" | grep -P -o -m 1 '(?<=inet\s)[^\s]+')
+docker_ip=$(ifconfig "${docker_interface}" | grep -P -o -m 1 '(?<=inet\s)[^\s]+' | sed 's/addr://')
 if [[ "${DEBUG}" == "true" ]]; then
 	echo "[debug] Docker IP defined as ${docker_ip}"
 fi
 
 # identify netmask for docker bridge interface
-docker_mask=$(ifconfig "${docker_interface}" | grep -P -o -m 1 '(?<=netmask\s)[^\s]+')
+docker_mask=$(ifconfig "${docker_interface}" | grep -P -o -m 1 '(?<=[mM]ask[\s:])[^\s]+')
 if [[ "${DEBUG}" == "true" ]]; then
 	echo "[debug] Docker netmask defined as ${docker_mask}"
 fi


### PR DESCRIPTION
I worked over the weekend trying to make your image creation process work with alpine instead of archlinux, but it was failing. The iptables output had a different entry for the docker network and was rejecting my connections. It all boiled down to a different ifconfig output.

Probably a better fix would be to move the ifconfig output to "ip ad show dev ${docker_interface}" instead of trying to parse the output of a tool that has not been consistently ported to different linux flavours.