### PR TITLE
Bump peer id to 2.0.5

### DIFF
--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -57,7 +57,7 @@ mkdir -p /home/nobody/.cache/Python-Eggs
 chmod -R 700 /home/nobody/.cache/Python-Eggs
 
 # change peerid to appear to be 2.0.3 stable - note this does not work for all/any private trackers at present
-sed -i -e "s~peer_id = substitute_chr(peer_id, 6, release_chr)~peer_id = \'-DE203s-\'\n        release_chr = \'s\'~g" /usr/lib/python3*/site-packages/deluge/core/core.py
+sed -i -e "s~peer_id = substitute_chr(peer_id, 6, release_chr)~peer_id = \'-DE205s-\'\n        release_chr = \'s\'~g" /usr/lib/python3*/site-packages/deluge/core/core.py
 
 # container perms
 ####


### PR DESCRIPTION
Deluge was updated to 2.0.5. This catches up the peer id set during install.

This mirrors this pull request: https://github.com/binhex/arch-deluge/pull/9