### PR TITLE
Adding support for custom themes of deluge web ui

### DIFF
--- a/.github/workflows/workflow-docker-manual.yml
+++ b/.github/workflows/workflow-docker-manual.yml
@@ -11,6 +11,11 @@ jobs:
   gcr-dockerhub-build-publish:
     runs-on: ubuntu-latest
     steps:
+      - name: set lower case repository name
+        run: |
+          echo "REPO_LC=${REPO,,}" >>${GITHUB_ENV}
+        env:
+          REPO: '${{ github.repository_owner }}'
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up QEMU for multi-arch support
@@ -72,7 +77,7 @@ jobs:
           with: |
             context: .
             load: true
-            tags: ghcr.io/${{ github.repository }}:${{ steps.generate_temporary_tag_name.outputs.test_tag }}
+            tags: ghcr.io/${{ REPO_LC }}:${{ steps.generate_temporary_tag_name.outputs.test_tag }}
             build-args: |
               RELEASETAG=${{ github.event.inputs.tags }}
           attempt_limit: 3

--- a/.github/workflows/workflow-docker-manual.yml
+++ b/.github/workflows/workflow-docker-manual.yml
@@ -72,7 +72,7 @@ jobs:
           with: |
             context: .
             load: true
-            tags: ghcr.io/${{ github.repository }}:${{ steps.generate_temporary_tag_name.outputs.test_tag }}
+            tags: ghcr.io/${{ github.repository,, }}:${{ steps.generate_temporary_tag_name.outputs.test_tag }}
             build-args: |
               RELEASETAG=${{ github.event.inputs.tags }}
           attempt_limit: 3

--- a/.github/workflows/workflow-docker-manual.yml
+++ b/.github/workflows/workflow-docker-manual.yml
@@ -72,7 +72,7 @@ jobs:
           with: |
             context: .
             load: true
-            tags: ghcr.io/${{ github.repository,, }}:${{ steps.generate_temporary_tag_name.outputs.test_tag }}
+            tags: ghcr.io/${{ github.repository },,}:${{ steps.generate_temporary_tag_name.outputs.test_tag }}
             build-args: |
               RELEASETAG=${{ github.event.inputs.tags }}
           attempt_limit: 3

--- a/.github/workflows/workflow-docker-manual.yml
+++ b/.github/workflows/workflow-docker-manual.yml
@@ -72,7 +72,7 @@ jobs:
           with: |
             context: .
             load: true
-            tags: ghcr.io/${{ github.repository },,}:${{ steps.generate_temporary_tag_name.outputs.test_tag }}
+            tags: ghcr.io/${{ github.repository }}:${{ steps.generate_temporary_tag_name.outputs.test_tag }}
             build-args: |
               RELEASETAG=${{ github.event.inputs.tags }}
           attempt_limit: 3

--- a/.github/workflows/workflow-docker-manual.yml
+++ b/.github/workflows/workflow-docker-manual.yml
@@ -77,7 +77,7 @@ jobs:
           with: |
             context: .
             load: true
-            tags: ghcr.io/${{ REPO_LC }}:${{ steps.generate_temporary_tag_name.outputs.test_tag }}
+            tags: ghcr.io/${{ env.REPO_LC }}:${{ steps.generate_temporary_tag_name.outputs.test_tag }}
             build-args: |
               RELEASETAG=${{ github.event.inputs.tags }}
           attempt_limit: 3

--- a/.github/workflows/workflow-docker-manual.yml
+++ b/.github/workflows/workflow-docker-manual.yml
@@ -88,7 +88,7 @@ jobs:
           git_clone_scripts_dest="/tmp/scripts"
           git_clone_scripts_repo="https://github.com/binhex/scripts.git"
           git clone "${git_clone_scripts_repo}" "${git_clone_scripts_dest}"
-          "${git_clone_scripts_dest}/shell/arch/docker/testrunner.sh" --app-name ${{ steps.generate_app_name.outputs.app_name }} --image-name "ghcr.io/${{ github.repository }}:${{ steps.generate_temporary_tag_name.outputs.test_tag }}"
+          "${git_clone_scripts_dest}/shell/arch/docker/testrunner.sh" --app-name ${{ steps.generate_app_name.outputs.app_name }} --image-name "ghcr.io/${{ env.REPO_LC }}:${{ steps.generate_temporary_tag_name.outputs.test_tag }}"
       # note this will re-use the internal cached amd64 image from the previous build
       - name: Build multi-arch Docker image, tag and push to registries
         uses: Wandalen/wretry.action@v3
@@ -98,7 +98,7 @@ jobs:
             context: .
             platforms: linux/amd64,linux/arm64
             push: true
-            tags: ${{ github.repository }}:${{ github.event.inputs.tags }}, ghcr.io/${{ github.repository }}:${{ github.event.inputs.tags }}
+            tags: ${{ env.REPO_LC }}:${{ github.event.inputs.tags }}, ghcr.io/${{ env.REPO_LC }}:${{ github.event.inputs.tags }}
             build-args: |
               RELEASETAG=${{ github.event.inputs.tags }}
           attempt_limit: 3

--- a/.github/workflows/workflow-docker-manual.yml
+++ b/.github/workflows/workflow-docker-manual.yml
@@ -28,18 +28,18 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
-      - name: Login to Quay
-        uses: docker/login-action@v3
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-      - name: Login to GitLab
-        uses: docker/login-action@v3
-        with:
-          registry: registry.gitlab.com
-          username: ${{ secrets.GITLAB_USERNAME }}
-          password: ${{ secrets.GITLAB_TOKEN }}
+#      - name: Login to Quay
+#        uses: docker/login-action@v3
+#        with:
+#          registry: quay.io
+#          username: ${{ secrets.QUAY_USERNAME }}
+#          password: ${{ secrets.QUAY_TOKEN }}
+#      - name: Login to GitLab
+#        uses: docker/login-action@v3
+#        with:
+#          registry: registry.gitlab.com
+#          username: ${{ secrets.GITLAB_USERNAME }}
+#          password: ${{ secrets.GITLAB_TOKEN }}
       - name: Sync GitHub README.md with Docker Hub
         uses: peter-evans/dockerhub-description@v4
         with:
@@ -93,7 +93,7 @@ jobs:
             context: .
             platforms: linux/amd64,linux/arm64
             push: true
-            tags: ${{ github.repository }}:${{ github.event.inputs.tags }}, quay.io/${{ github.repository }}:${{ github.event.inputs.tags }}, ghcr.io/${{ github.repository }}:${{ github.event.inputs.tags }}, registry.gitlab.com/${{ github.repository }}:${{ github.event.inputs.tags }}
+            tags: ${{ github.repository }}:${{ github.event.inputs.tags }}, ghcr.io/${{ github.repository }}:${{ github.event.inputs.tags }}
             build-args: |
               RELEASETAG=${{ github.event.inputs.tags }}
           attempt_limit: 3

--- a/.github/workflows/workflow-docker-release.yml
+++ b/.github/workflows/workflow-docker-release.yml
@@ -107,7 +107,7 @@ jobs:
             context: .
             platforms: linux/amd64,linux/arm64
             push: true
-            tags: ${{ env.REPO_LC }}:latest, ${{ env.REPO_LC }}:${{ steps.identify_github_release_tag_name.outputs.tag }}, ghcr.io/${{ github.repository }}:latest, ghcr.io/${{ github.repository }}:${{ steps.identify_github_release_tag_name.outputs.tag }}
+            tags: ${{ env.REPO_LC }}:latest, ${{ env.REPO_LC }}:${{ steps.identify_github_release_tag_name.outputs.tag }}, ghcr.io/${{ env.REPO_LC }}:latest, ghcr.io/${{ env.REPO_LC }}:${{ steps.identify_github_release_tag_name.outputs.tag }}
             build-args: |
               RELEASETAG=${{ steps.identify_github_release_tag_name.outputs.tag }}
           attempt_limit: 3

--- a/.github/workflows/workflow-docker-release.yml
+++ b/.github/workflows/workflow-docker-release.yml
@@ -9,6 +9,11 @@ jobs:
   gcr-dockerhub-build-publish:
     runs-on: ubuntu-latest
     steps:
+      - name: set lower case repository name
+        run: |
+          echo "REPO_LC=${REPO,,}" >>${GITHUB_ENV}
+        env:
+          REPO: '${{ github.repository_owner }}'
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up QEMU for multi-arch support
@@ -81,7 +86,7 @@ jobs:
           with: |
             context: .
             load: true
-            tags: ghcr.io/${{ github.repository }}:${{ steps.generate_temporary_tag_name.outputs.test_tag }}
+            tags: ghcr.io/${{ env.REPO_LC }}:${{ steps.generate_temporary_tag_name.outputs.test_tag }}
             build-args: |
               RELEASETAG=${{ steps.identify_github_release_tag_name.outputs.tag }}
           attempt_limit: 3
@@ -92,7 +97,7 @@ jobs:
           git_clone_scripts_dest="/tmp/scripts"
           git_clone_scripts_repo="https://github.com/binhex/scripts.git"
           git clone "${git_clone_scripts_repo}" "${git_clone_scripts_dest}"
-          "${git_clone_scripts_dest}/shell/arch/docker/testrunner.sh" --app-name ${{ steps.generate_app_name.outputs.app_name }} --image-name "ghcr.io/${{ github.repository }}:${{ steps.generate_temporary_tag_name.outputs.test_tag }}"
+          "${git_clone_scripts_dest}/shell/arch/docker/testrunner.sh" --app-name ${{ steps.generate_app_name.outputs.app_name }} --image-name "ghcr.io/${{ env.REPO_LC }}:${{ steps.generate_temporary_tag_name.outputs.test_tag }}"
       # note this will re-use the internal cached amd64 image from the previous build
       - name: Build multi-arch Docker image, tag and push to registries
         uses: Wandalen/wretry.action@v3
@@ -102,7 +107,7 @@ jobs:
             context: .
             platforms: linux/amd64,linux/arm64
             push: true
-            tags: ${{ github.repository }}:latest, ${{ github.repository }}:${{ steps.identify_github_release_tag_name.outputs.tag }}, quay.io/${{ github.repository }}:latest, quay.io/${{ github.repository }}:${{ steps.identify_github_release_tag_name.outputs.tag }}, ghcr.io/${{ github.repository }}:latest, ghcr.io/${{ github.repository }}:${{ steps.identify_github_release_tag_name.outputs.tag }}, registry.gitlab.com/${{ github.repository }}:latest, registry.gitlab.com/${{ github.repository }}:${{ steps.identify_github_release_tag_name.outputs.tag }}
+            tags: ${{ env.REPO_LC }}:latest, ${{ env.REPO_LC }}:${{ steps.identify_github_release_tag_name.outputs.tag }}, ghcr.io/${{ github.repository }}:latest, ghcr.io/${{ github.repository }}:${{ steps.identify_github_release_tag_name.outputs.tag }}
             build-args: |
               RELEASETAG=${{ steps.identify_github_release_tag_name.outputs.tag }}
           attempt_limit: 3

--- a/.github/workflows/workflow-docker-release.yml
+++ b/.github/workflows/workflow-docker-release.yml
@@ -31,18 +31,18 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
-      - name: Login to Quay
-        uses: docker/login-action@v3
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-      - name: Login to GitLab
-        uses: docker/login-action@v3
-        with:
-          registry: registry.gitlab.com
-          username: ${{ secrets.GITLAB_USERNAME }}
-          password: ${{ secrets.GITLAB_TOKEN }}
+      #- name: Login to Quay
+      #  uses: docker/login-action@v3
+      #  with:
+      #    registry: quay.io
+      #    username: ${{ secrets.QUAY_USERNAME }}
+      #    password: ${{ secrets.QUAY_TOKEN }}
+      #- name: Login to GitLab
+      #  uses: docker/login-action@v3
+      #  with:
+      #    registry: registry.gitlab.com
+      #    username: ${{ secrets.GITLAB_USERNAME }}
+      #    password: ${{ secrets.GITLAB_TOKEN }}
       - name: Sync GitHub README.md with Docker Hub
         uses: peter-evans/dockerhub-description@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ ADD build/*.conf /etc/supervisor/conf.d/
 # add bash scripts to install app
 ADD build/root/*.sh /root/
 
+# add bash script to keep custom theme files updated
+ADD run/root/*.sh /home/root/
+
 # add bash script to run deluge
 ADD run/nobody/*.sh /home/nobody/
 

--- a/build/delugevpn.conf
+++ b/build/delugevpn.conf
@@ -5,11 +5,17 @@ user = root
 command = /root/start.sh
 umask = 000
 
+[program:themes-script]
+autorestart = false
+startsecs = 0
+user = root
+command = /home/root/updatethemes.sh
+umask = 000
+
 [program:watchdog-script]
 autorestart = false
 startsecs = 0
 user = nobody
 command = /home/nobody/watchdog.sh
 umask = 000
-
 

--- a/run/root/updatethemes.sh
+++ b/run/root/updatethemes.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/dumb-init /bin/bash
+
+# create folders if they don't exist
+if [[ ! -d /skins ]]; then
+	echo "[info] /skins folder doesn't exist, creating..."
+    mkdir /skins
+    mkdir /skins/themes
+    mkdir /skins/icons
+    mkdir /skins/images
+fi
+
+# cleanup broken symlinks
+echo "[info] Cleaning up old custom deluge web ui skin symlinks"
+find /usr/lib/python3.12/site-packages/deluge/ui/web/themes/ -type l -exec unlink {} \;
+find /usr/lib/python3.12/site-packages/deluge/ui/web/icons/ -type l -exec unlink {} \;
+find /usr/lib/python3.12/site-packages/deluge/ui/web/images/ -type l -exec unlink {} \;
+
+# map current skin files to repective deluge web ui folders
+echo "[info] Creating new custom deluge web ui skin symlinks"
+cp -rs /skins/themes /usr/lib/python3.12/site-packages/deluge/ui/web/
+cp -rs /skins/icons /usr/lib/python3.12/site-packages/deluge/ui/web/
+cp -rs /skins/images /usr/lib/python3.12/site-packages/deluge/ui/web/


### PR DESCRIPTION
Added a script to be run by root at boot of container that provides support for adding custom themes to the deluge web ui by performing the following actions:

1. Check for the presence of the /skins/themes, /skins/icons, and /skin/images folders and creates them if they are not present
2. Checks for broken symlinks from the last run and removes them with unlink
3. Creates new symlinks to reflect the current state of the files in the /skins sub-folders

tldr; Added a script that symlinks the contents of /skins/themes, /skins/icons, and /skins/images to the relevant deluge web ui folders currently located at /usr/lib/python3.12/site-packages/deluge/ui/web. This allows a user to add a persistent set of custom theme files to the /skins folders using volume mounting. To apply a theme, the user still must modify the /config/web.conf file while the container is not running.