### PR TITLE
Add support for custom web ui themes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ ADD build/*.conf /etc/supervisor/conf.d/
 # add bash scripts to install app
 ADD build/root/*.sh /root/
 
+# add bash script to keep custom theme files updated
+ADD run/root/*.sh /home/root/
+
 # add bash script to run deluge
 ADD run/nobody/*.sh /home/nobody/
 

--- a/build/delugevpn.conf
+++ b/build/delugevpn.conf
@@ -5,11 +5,17 @@ user = root
 command = /root/start.sh
 umask = 000
 
+[program:themes-script]
+autorestart = false
+startsecs = 0
+user = root
+command = /home/root/updatethemes.sh
+umask = 000
+
 [program:watchdog-script]
 autorestart = false
 startsecs = 0
 user = nobody
 command = /home/nobody/watchdog.sh
 umask = 000
-
 

--- a/run/root/updatethemes.sh
+++ b/run/root/updatethemes.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/dumb-init /bin/bash
+
+# create folders if they don't exist
+if [[ ! -d /skins ]]; then
+	echo "[info] /skins folder doesn't exist, creating..."
+    mkdir /skins
+    mkdir /skins/themes
+    mkdir /skins/icons
+    mkdir /skins/images
+fi
+
+# cleanup broken symlinks
+echo "[info] Cleaning up old custom deluge web ui skin symlinks"
+find /usr/lib/python3.12/site-packages/deluge/ui/web/themes/ -type l -exec unlink {} \;
+find /usr/lib/python3.12/site-packages/deluge/ui/web/icons/ -type l -exec unlink {} \;
+find /usr/lib/python3.12/site-packages/deluge/ui/web/images/ -type l -exec unlink {} \;
+
+# map current skin files to repective deluge web ui folders
+echo "[info] Creating new custom deluge web ui skin symlinks"
+cp -rs /skins/themes /usr/lib/python3.12/site-packages/deluge/ui/web/
+cp -rs /skins/icons /usr/lib/python3.12/site-packages/deluge/ui/web/
+cp -rs /skins/images /usr/lib/python3.12/site-packages/deluge/ui/web/


### PR DESCRIPTION
Added a script to be run by root at boot of container that provides support for adding custom themes to the deluge web ui by performing the following actions:

1.     Check for the presence of the /skins/themes, /skins/icons, and /skin/images folders and creates them if they are not present
2.     Checks for broken symlinks from the last run and removes them with unlink
3.     Creates new symlinks to reflect the current state of the files in the /skins sub-folders

The contents of the /skins/themes, /skins/icons, and /skins/images folders are mapped to the relevant deluge web ui folders currently located at /usr/lib/python3.12/site-packages/deluge/ui/web.  This allows a user to add a persistent set of custom theme files to the /skins folders using volume mounting.

TLDR; User creates volume mounts for the /skins sub-folders and places custom theme files in them. While the container is not running, the user modifies the /config/web.conf file to specify the custom theme to be used on next run.
