### PR TITLE
fix: restart deluge-web when deluged is restarted by watchdog

### DIFF
--- a/run/nobody/deluge.sh
+++ b/run/nobody/deluge.sh
@@ -17,6 +17,17 @@ export PYTHON_EGG_CACHE="${python_egg_cache}"
 
 if [[ "${deluge_running}" == "false" ]]; then
 
+	# if deluge-web is still running, stop it so it gets restarted with a
+	# fresh RPC connection to the new daemon instance. Without this,
+	# deluge-web holds a stale connection and enters an endless
+	# connect/disconnect loop, leaving the Web UI stuck on the
+	# Connection Manager screen.
+	if [[ "${deluge_web_running}" == "true" ]]; then
+		echo "[info] Stopping Deluge Web UI before daemon restart to avoid stale RPC connection..."
+		pkill -SIGTERM -x "deluge-web"
+		deluge_web_running="false"
+	fi
+
 	echo "[info] Attempting to start Deluge..."
 
 	echo "[info] Removing deluge pid file (if it exists)..."


### PR DESCRIPTION
When `deluged` crashes (e.g. segfault in libtorrent) and the watchdog restarts it, `deluge-web` is left running with a stale RPC connection to the old daemon.

It enters an endless connect/disconnect loop every ~2s:

```
Deluge Client connection made from: 127.0.0.1:49726
Deluge client disconnected: Connection to the other side was lost in a non-clean fashion: Connection lost.
Deluge Client connection made from: 127.0.0.1:49740
Deluge client disconnected: Connection to the other side was lost in a non-clean fashion: Connection lost.
...
```

The web UI loads but gets stuck on the Connection Manager screen. Only fix is restarting the whole container.

**Root cause:** in `deluge.sh`, when `deluge_running == "false"` the daemon gets restarted, but `deluge-web` is only started when `deluge_web_running == "false"`. Since the web process is still alive (just with a broken RPC connection), it never gets restarted. `deluge-web` doesn't reconnect on its own when the daemon PID changes.

**Fix:** single file change in `apps/nobody/deluge.sh`. Before restarting `deluged`, kill `deluge-web` with SIGTERM and set `deluge_web_running="false"`. The logic futher down in `deluge.sh` then starts it fresh alongside the new daemon.

Reproduced on `binhex/arch-delugevpn:latest`, Deluge 2.2.0, libtorrent 2.0.11-4, Python 3.13.7, boost 1.88.0-3. Confirmed via `coredumpctl` that `deluged` segfaults periodicaly in libtorrent which triggers the watchdog restart path.